### PR TITLE
Refactor registry auth configuration and remove unused code

### DIFF
--- a/configs/configfile.go
+++ b/configs/configfile.go
@@ -14,17 +14,10 @@ type CLI struct {
 	DockerConfigFilePath string `help:"Path to the docker config file which is used to access registry credentials." default:"~/.docker/config.json" env:"DOCKER_CONFIG_FILE_PATH"`
 	LogLevel             string `help:"Server log level." default:"info" enum:"debug,info,warn,error" env:"DORAS_LOG_LEVEL"`
 	ShutdownTimout       uint   `help:"Graceful shutdown timeout (in seconds)." default:"20" env:"DORAS_SHUTDOWN_TIMEOUT"`
+	InsecureAllowHTTP    bool   `help:"Allow INSECURE HTTP connections." default:"false" env:"DORAS_INSECURE_ALLOW_HTTP"`
 }
 
 // ServerConfigFile is used to parse the config files that can be used for more extensive configuration.
 type ServerConfigFile struct {
-	Storage        StorageConfiguration `yaml:"storage"`
-	TrustedProxies []string             `yaml:"trusted-proxies"`
-}
-
-// StorageConfiguration is used to configure a registry that is used to store artifacts and deltas.
-type StorageConfiguration struct {
-	Kind       string `yaml:"kind"`
-	URL        string `yaml:"url"`
-	EnableHTTP bool   `yaml:"enable-http"`
+	TrustedProxies []string `yaml:"trusted-proxies"`
 }

--- a/internal/pkg/core/dorasengine/dorasengine_test.go
+++ b/internal/pkg/core/dorasengine/dorasengine_test.go
@@ -246,7 +246,7 @@ func Test_readDelta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	delegate := deltadelegate.NewDeltaDelegate("registry.example.org")
+	delegate := deltadelegate.NewDeltaDelegate()
 
 	type args struct {
 		registry    registrydelegate.RegistryDelegate
@@ -365,7 +365,7 @@ func Test_readDelta_Token(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	delegate := deltadelegate.NewDeltaDelegate("registry.example.org")
+	delegate := deltadelegate.NewDeltaDelegate()
 
 	type args struct {
 		registry    registrydelegate.RegistryDelegate

--- a/internal/pkg/delegates/delta/deltadelegate.go
+++ b/internal/pkg/delegates/delta/deltadelegate.go
@@ -20,16 +20,13 @@ import (
 )
 
 type delegate struct {
-	baseUrl        string
 	activeRequests map[string]any
 	m              sync.Mutex
 }
 
 // NewDeltaDelegate construct a DeltaDelegate that is used to handle delta creation operations.
-// The baseUrl affects repository names/paths.
-func NewDeltaDelegate(baseUrl string) DeltaDelegate {
+func NewDeltaDelegate() DeltaDelegate {
 	return &delegate{
-		baseUrl:        baseUrl,
 		activeRequests: make(map[string]any),
 		m:              sync.Mutex{},
 	}

--- a/test/e2e/deltaapi_test.go
+++ b/test/e2e/deltaapi_test.go
@@ -61,15 +61,9 @@ func Test_ReadAndApplyDelta(t *testing.T) {
 	regUri := testutils2.LaunchRegistry(ctx)
 
 	host := "localhost:8081"
-	configFile := configs.ServerConfigFile{
-		Storage: configs.StorageConfiguration{
-			URL:        regUri,
-			EnableHTTP: true,
-		},
-	}
 	serverConfig := configs.ServerConfig{
-		ConfigFile: configFile,
-		CliOpts:    configs.CLI{HTTPPort: 8081, Host: "localhost", LogLevel: "debug"},
+		ConfigFile: configs.ServerConfigFile{},
+		CliOpts:    configs.CLI{HTTPPort: 8081, Host: "localhost", LogLevel: "debug", InsecureAllowHTTP: true},
 	}
 	dorasServer := core.New(serverConfig)
 	go dorasServer.Start()


### PR DESCRIPTION
## Description

- Add CLI/env flag to configure allowing insecure HTTP connections to registries.
- Remove now obsolete options from the doras server config file.
- Refactor internals and use the provided docker config file to authenticate to the registries.


Closes #37 