### PR TITLE
Add read-delta command to CLI and other improvements.

### DIFF
--- a/cmd/doras-cli/delta.go
+++ b/cmd/doras-cli/delta.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/unbasical/doras-server/internal/pkg/api/apicommon"
+	"github.com/unbasical/doras-server/internal/pkg/client"
+	"github.com/unbasical/doras-server/internal/pkg/utils/ociutils"
+	"github.com/unbasical/doras-server/pkg/client/edgeapi"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+func (args *cliArgs) readDelta(ctx context.Context) error {
+	_ = ctx
+
+	// try to load credentials
+	creds, err := args.getCredentialFunc()
+	if err != nil {
+		return err
+	}
+	var tokenProvider client.AuthTokenProvider
+	tokenProvider, err = newCredentialFuncTokenProvider(creds, args.ReadDelta.From)
+	if err != nil {
+		log.WithError(err).Info("did not load any auth token providers")
+	}
+	dorasClient, err := edgeapi.NewEdgeClient(
+		args.Remote,
+		args.InsecureAllowHTTP,
+		tokenProvider,
+	)
+	if err != nil {
+		return err
+	}
+	var res *apicommon.ReadDeltaResponse
+	// If the async flag is not set we do not block.
+	if args.ReadDelta.Async {
+		log.Info("asynchronously requesting delta")
+		var exists bool
+		res, exists, err = dorasClient.ReadDeltaAsync(args.ReadDelta.From, args.ReadDelta.To, nil)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			log.Info("delta has not been created yet")
+			return nil
+		}
+	} else {
+		res, err = dorasClient.ReadDelta(args.ReadDelta.From, args.ReadDelta.To, nil)
+		if err != nil {
+			return err
+		}
+	}
+	// print server response
+	resJSON, err := json.Marshal(res)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", resJSON)
+	return nil
+}
+
+type credentialFuncTokenProvider struct {
+	auth.CredentialFunc
+	registry string
+}
+
+// newCredentialFuncTokenProvider creates a token provider that uses the provided auth.CredentialFunc to load access tokens.
+// Only works if the credential function is token based.
+func newCredentialFuncTokenProvider(creds auth.CredentialFunc, image string) (client.AuthTokenProvider, error) {
+	url, err := ociutils.ParseOciUrl(image)
+	if err != nil {
+		return nil, err
+	}
+	return &credentialFuncTokenProvider{
+		CredentialFunc: creds,
+		registry:       url.Host,
+	}, nil
+}
+
+func (c *credentialFuncTokenProvider) GetAuthToken() (string, error) {
+	credential, err := c.CredentialFunc(context.Background(), c.registry)
+	if err != nil {
+		return "", err
+	}
+	if credential.AccessToken == "" {
+		return "", errors.New("no access token found")
+	}
+	return credential.AccessToken, nil
+}

--- a/cmd/doras-cli/main.go
+++ b/cmd/doras-cli/main.go
@@ -14,7 +14,7 @@ type cliArgs struct {
 	LogLevel             string `help:"Log level." default:"info" enum:"debug,info,warn,error" env:"DORAS_LOG_LEVEL"`
 	LogFormat            string `help:"Log format." default:"text" enum:"json,text" env:"DORAS_LOG_FORMAT"`
 	InsecureAllowHTTP    bool   `help:"Allow INSECURE HTTP connections." default:"false" env:"DORAS_INSECURE_ALLOW_HTTP"`
-	Remote               string `help:"The URL of the Doras server." default:"localhost:8080" env:"DORAS_SERVER_URL"`
+	Remote               string `help:"The URL of the Doras server." default:"http://localhost:8080" env:"DORAS_SERVER_URL"`
 	Push                 struct {
 		Compress     string `help:"Compress artifact before uploading." default:"gzip" enum:"zstd,gzip,none"`
 		ArchiveFiles bool   `help:"Archive artifact before uploading." default:"false"`
@@ -24,7 +24,12 @@ type cliArgs struct {
 	Pull struct {
 		Image  string `arg:"" name:"image" help:"Target image/repository which is pulled."`
 		Output string `help:"Output directory." type:"path" default:"."`
-	} `cmd:"" name:"pull" help:"Pull an artifact from a registry, uses delta updates if possible."`
+	} `cmd:"" name:"pull" help:"Pull an artifact from a registry, uses readDelta updates if possible."`
+	ReadDelta struct {
+		From  string `help:"From which image the delta will be built."`
+		To    string `help:"To which image the delta will be built."`
+		Async bool   `help:"Do not block until the delta is created." default:"false"`
+	} `cmd:"" help:"Request a delta image from the Doras server."`
 }
 
 func main() {
@@ -43,6 +48,8 @@ func main() {
 		err = args.push(ctx)
 	case "pull <image>":
 		err = args.pull(ctx)
+	case "read-delta":
+		err = args.readDelta(ctx)
 	default:
 		log.Fatalf("Unknown command: %v", cliCtx.Command())
 	}

--- a/cmd/doras-cli/push.go
+++ b/cmd/doras-cli/push.go
@@ -227,7 +227,7 @@ func pushAndTag(ctx context.Context, target oras.Target, d v1.Descriptor, conten
 	if err != nil {
 		return v1.Descriptor{}, err
 	}
-
+	log.Infof("manifest descriptor: %v", mfDesc)
 	// Tag the image.
 	if err = target.Tag(ctx, mfDesc, tag); err != nil {
 		return v1.Descriptor{}, fmt.Errorf("failed to tag manifest: %v", err)

--- a/cmd/doras-server/main.go
+++ b/cmd/doras-server/main.go
@@ -26,7 +26,7 @@ func main() {
 	var configFile configs.ServerConfigFile
 	exists, err := fileutils.SafeReadYAML(serverConfig.CliOpts.ConfigFilePath, &serverConfig.ConfigFile, os.FileMode(0644))
 	if !exists || err != nil {
-		log.Fatalf("Error reading configFile file %s: %s", serverConfig.CliOpts.ConfigFilePath, err)
+		log.Errorf("Error reading configFile file %s: %s", serverConfig.CliOpts.ConfigFilePath, err)
 	}
 	log.Debugf("Config: %+v", configFile)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,11 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+    environment:
+      DORAS_HOST: 0.0.0.0
+      DORAS_INSECURE_ALLOW_HTTP: True
+      DORAS_LOG_LEVEL: debug
+
   registry:
     image: registry:2.8
     environment:

--- a/pkg/client/updater/builder.go
+++ b/pkg/client/updater/builder.go
@@ -12,7 +12,6 @@ type clientOpts struct {
 	OutputDirectory    string
 	InternalDirectory  string
 	DockerConfigPath   string
-	RegistryURL        string
 	AcceptedAlgorithms []string
 }
 
@@ -29,7 +28,7 @@ func NewClient(options ...func(*Client)) (*Client, error) {
 	for _, option := range options {
 		option(client)
 	}
-	c, err := edgeapi.NewEdgeClient(client.opts.RemoteURL, client.opts.RegistryURL, true, nil)
+	c, err := edgeapi.NewEdgeClient(client.opts.RemoteURL, true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -42,13 +41,6 @@ func NewClient(options ...func(*Client)) (*Client, error) {
 func WithRemoteURL(remoteURL string) func(*Client) {
 	return func(c *Client) {
 		c.opts.RemoteURL = remoteURL
-	}
-}
-
-// WithRegistry adds a registry URL to the client configuration.
-func WithRegistry(registry string) func(*Client) {
-	return func(c *Client) {
-		c.opts.RegistryURL = registry
 	}
 }
 

--- a/test/e2e/deltaapi_test.go
+++ b/test/e2e/deltaapi_test.go
@@ -147,7 +147,7 @@ func Test_ReadAndApplyDelta(t *testing.T) {
 		}
 	}
 
-	edgeClient, err := edgeapi.NewEdgeClient(fmt.Sprintf("http://%s", host), regUri, true, nil)
+	edgeClient, err := edgeapi.NewEdgeClient(fmt.Sprintf("http://%s", host), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

- Add `doras-cli read-delta` command.
- Fix bug that causes crashing if no doras server config is provided.
- Update `docker-compose.yaml`.
- Remove unused code from client.