### PR TITLE
Allow servers to require clients to provide an authentication token

### DIFF
--- a/configs/configfile.go
+++ b/configs/configfile.go
@@ -15,6 +15,7 @@ type CLI struct {
 	LogLevel             string `help:"Server log level." default:"info" enum:"debug,info,warn,error" env:"DORAS_LOG_LEVEL"`
 	ShutdownTimout       uint   `help:"Graceful shutdown timeout (in seconds)." default:"20" env:"DORAS_SHUTDOWN_TIMEOUT"`
 	InsecureAllowHTTP    bool   `help:"Allow INSECURE HTTP connections." default:"false" env:"DORAS_INSECURE_ALLOW_HTTP"`
+	RequireClientAuth    bool   `help:"Always require clients to provide an authentication token, regardless of repo access rights." default:"true" env:"DORAS_REQUIRE_CLIENT_AUTH"`
 	ExampleConfig        struct {
 		Output string `help:"Write example config to this location instead of printing to stdout." type:"path"`
 	} `cmd:"" help:"Print or store example config."`

--- a/internal/pkg/api/api.go
+++ b/internal/pkg/api/api.go
@@ -19,6 +19,9 @@ func logger() gin.HandlerFunc {
 		startTime := time.Now()
 		c.Next()
 		latency := time.Since(startTime)
+		if c.Request.URL.Path == "/api/v1/ping" {
+			return
+		}
 		log.WithFields(log.Fields{
 			"status":    c.Writer.Status(),
 			"method":    c.Request.Method,

--- a/internal/pkg/api/gindelegate/delegate.go
+++ b/internal/pkg/api/gindelegate/delegate.go
@@ -73,6 +73,12 @@ func (g *ginDorasContext) HandleError(err error, msg string) {
 	if errors.Is(err, error2.ErrMissingQueryParam) {
 		statusCode = http.StatusBadRequest
 	}
+	if errors.Is(err, error2.ErrUnauthorized) {
+		statusCode = http.StatusUnauthorized
+	}
+	if errors.Is(err, error2.ErrFailedToResolve) {
+		statusCode = http.StatusNotFound
+	}
 	RespondWithError(g.c, statusCode, err, msg)
 }
 

--- a/internal/pkg/core/core.go
+++ b/internal/pkg/core/core.go
@@ -75,7 +75,7 @@ func (d *Doras) init(config configs.ServerConfig) *Doras {
 	registryDelegate := registrydelegate.NewRegistryDelegate(creds, config.CliOpts.InsecureAllowHTTP)
 	deltaDelegate := deltadelegate.NewDeltaDelegate()
 
-	dorasEngine := dorasengine.NewEngine(registryDelegate, deltaDelegate)
+	dorasEngine := dorasengine.NewEngine(registryDelegate, deltaDelegate, config.CliOpts.RequireClientAuth)
 	r := api.BuildApp(dorasEngine)
 	err := r.SetTrustedProxies(config.ConfigFile.TrustedProxies)
 	if err != nil {

--- a/internal/pkg/core/dorasengine/dorasengine.go
+++ b/internal/pkg/core/dorasengine/dorasengine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"strings"
 	"sync"
 
 	apidelegate "github.com/unbasical/doras/internal/pkg/delegates/api"
@@ -29,17 +30,19 @@ type Engine interface {
 }
 
 type engine struct {
-	registry registrydelegate.RegistryDelegate
-	delegate deltadelegate.DeltaDelegate
-	wg       *sync.WaitGroup
+	registry          registrydelegate.RegistryDelegate
+	delegate          deltadelegate.DeltaDelegate
+	requireClientAuth bool
+	wg                *sync.WaitGroup
 }
 
 // NewEngine construct a new dorasengine.Engine with the given delegates.
-func NewEngine(registry registrydelegate.RegistryDelegate, delegate deltadelegate.DeltaDelegate) Engine {
+func NewEngine(registry registrydelegate.RegistryDelegate, delegate deltadelegate.DeltaDelegate, requireClientAuth bool) Engine {
 	return &engine{
-		registry: registry,
-		delegate: delegate,
-		wg:       &sync.WaitGroup{},
+		registry:          registry,
+		delegate:          delegate,
+		wg:                &sync.WaitGroup{},
+		requireClientAuth: requireClientAuth,
 	}
 }
 func (d *engine) Stop(ctx context.Context) {
@@ -58,7 +61,7 @@ func (d *engine) Stop(ctx context.Context) {
 
 func (d *engine) HandleReadDelta(apiDeletgate apidelegate.APIDelegate) {
 	ctx := context.WithValue(context.Background(), "wg", d.wg)
-	readDelta(ctx, d.registry, d.delegate, apiDeletgate)
+	readDelta(ctx, d.registry, d.delegate, apiDeletgate, d.requireClientAuth)
 }
 
 // checkRepoCompatability ensures that the two provided images are from the same repository.
@@ -78,7 +81,7 @@ func checkRepoCompatability(a, b string) error {
 }
 
 //nolint:revive // This rule is disabled to get around complexity linter errors. Reducing the complexity of this function is difficult. Refer to the Doras specs in the file docs/delta-creation-spec.md for more information on the semantics of this god function.
-func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, delegate deltadelegate.DeltaDelegate, apiDelegate apidelegate.APIDelegate) {
+func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, delegate deltadelegate.DeltaDelegate, apiDelegate apidelegate.APIDelegate, requireClientAuth bool) {
 	wg, ok := ctx.Value("wg").(*sync.WaitGroup)
 	if !ok {
 		panic("missing wait group in context")
@@ -88,19 +91,21 @@ func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, 
 	fromDigest, toTarget, acceptedAlgorithms, err := apiDelegate.ExtractParams()
 	if err != nil {
 		log.WithError(err).Error("Error extracting parameters")
-		apiDelegate.HandleError(error2.ErrInternal, "")
+		if requireClientAuth {
+			apiDelegate.HandleError(error2.ErrUnauthorized, "")
+			return
+		}
+		apiDelegate.HandleError(error2.ErrBadRequest, "")
 		return
 	}
-	err = checkRepoCompatability(fromDigest, toTarget)
-	if err != nil {
-		log.WithError(err).Error("Error checking repo compatibility")
-		apiDelegate.HandleError(error2.ErrInternal, err.Error())
-		return
-	}
-
 	var creds auth.CredentialFunc
-	if clientAuth, err := apiDelegate.ExtractClientAuth(); err != nil {
+	clientAuth, err := apiDelegate.ExtractClientAuth()
+	if err != nil {
 		log.WithError(err).Debug("Error extracting client token")
+		if requireClientAuth {
+			apiDelegate.HandleError(error2.ErrUnauthorized, "")
+			return
+		}
 	} else {
 		repoUrl, err := ociutils.ParseOciUrl(fromDigest)
 		if err != nil {
@@ -116,16 +121,31 @@ func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, 
 		}
 	}
 
+	err = checkRepoCompatability(fromDigest, toTarget)
+	if err != nil {
+		log.WithError(err).Error("Error checking repo compatibility")
+		apiDelegate.HandleError(error2.ErrInternal, err.Error())
+		return
+	}
+
 	// resolve images to ensure they exist
 	srcFrom, fromImage, fromDescriptor, err := registry.Resolve(fromDigest, true, creds)
 	if err != nil {
 		log.WithError(err).Errorf("Error resolving target %q", fromDigest)
-		apiDelegate.HandleError(error2.ErrInvalidOciImage, fromDigest)
+		if strings.Contains(err.Error(), "unauthorized") {
+			apiDelegate.HandleError(error2.ErrUnauthorized, "")
+			return
+		}
+		apiDelegate.HandleError(error2.ErrFailedToResolve, fromDigest)
 		return
 	}
 	srcTo, toImage, toDescriptor, err := registry.Resolve(toTarget, false, creds)
 	if err != nil {
 		log.WithError(err).Errorf("Error resolving target %q", toTarget)
+		if strings.Contains(err.Error(), "unauthorized") {
+			apiDelegate.HandleError(error2.ErrUnauthorized, "")
+			return
+		}
 		apiDelegate.HandleError(error2.ErrInvalidOciImage, toTarget)
 		return
 	}

--- a/internal/pkg/core/dorasengine/dorasengine.go
+++ b/internal/pkg/core/dorasengine/dorasengine.go
@@ -132,6 +132,7 @@ func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, 
 	srcFrom, fromImage, fromDescriptor, err := registry.Resolve(fromDigest, true, creds)
 	if err != nil {
 		log.WithError(err).Errorf("Error resolving target %q", fromDigest)
+		// assume there is the string "unauthorized" in the error message when there is an auth failure
 		if strings.Contains(err.Error(), "unauthorized") {
 			apiDelegate.HandleError(error2.ErrUnauthorized, "")
 			return
@@ -142,6 +143,7 @@ func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, 
 	srcTo, toImage, toDescriptor, err := registry.Resolve(toTarget, false, creds)
 	if err != nil {
 		log.WithError(err).Errorf("Error resolving target %q", toTarget)
+		// assume there is the string "unauthorized" in the error message when there is an auth failure
 		if strings.Contains(err.Error(), "unauthorized") {
 			apiDelegate.HandleError(error2.ErrUnauthorized, "")
 			return

--- a/internal/pkg/error/error.go
+++ b/internal/pkg/error/error.go
@@ -19,4 +19,6 @@ var (
 	ErrBadRequest                  = errors.New("bad request")
 	ErrInvalidOciImage             = errors.New("invalid oci image")
 	ErrMissingQueryParam           = errors.New("missing query param")
+	ErrUnauthorized                = errors.New("unauthorized")
+	ErrFailedToResolve             = errors.New("failed to resolve")
 )


### PR DESCRIPTION
## Description

- allow servers to require an client auth token before doing any other processing
  - this can be configured via a CLI flag/EnVar
- improve error responses for the server
- disable logging of ping endpoint
- improve test coverage