### PR TITLE
Introduce new type for manifests and support older oras manifests

### DIFF
--- a/internal/pkg/core/dorasengine/dorasengine.go
+++ b/internal/pkg/core/dorasengine/dorasengine.go
@@ -13,7 +13,6 @@ import (
 	registrydelegate "github.com/unbasical/doras/internal/pkg/delegates/registry"
 	"github.com/unbasical/doras/internal/pkg/utils/ociutils"
 
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/unbasical/doras/internal/pkg/algorithmchoice"
 	"github.com/unbasical/doras/internal/pkg/api/apicommon"
@@ -265,7 +264,7 @@ func readDelta(ctx context.Context, registry registrydelegate.RegistryDelegate, 
 	apiDelegate.HandleAccepted()
 }
 
-func checkCompatability(from *v1.Manifest, to *v1.Manifest) error {
+func checkCompatability(from *ociutils.Manifest, to *ociutils.Manifest) error {
 	if len(from.Layers) != len(to.Layers) {
 		return errors.New("incompatible amount of layers")
 	}

--- a/internal/pkg/core/dorasengine/dorasengine_test.go
+++ b/internal/pkg/core/dorasengine/dorasengine_test.go
@@ -72,20 +72,20 @@ func (t *testRegistryDelegate) Resolve(image string, expectDigest bool, creds au
 	return t.storage, image, d, nil
 }
 
-func (t *testRegistryDelegate) LoadManifest(target v1.Descriptor, source oras.ReadOnlyTarget) (v1.Manifest, error) {
+func (t *testRegistryDelegate) LoadManifest(target v1.Descriptor, source oras.ReadOnlyTarget) (ociutils.Manifest, error) {
 	rc, err := source.Fetch(t.ctx, target)
 	if err != nil {
-		return v1.Manifest{}, err
+		return ociutils.Manifest{}, err
 	}
 	defer funcutils.PanicOrLogOnErr(rc.Close, false, "failed to close reader")
 	mf, err := ociutils.ParseManifestJSON(rc)
 	if err != nil {
-		return v1.Manifest{}, err
+		return ociutils.Manifest{}, err
 	}
 	return *mf, nil
 }
 
-func (t *testRegistryDelegate) LoadArtifact(mf v1.Manifest, source oras.ReadOnlyTarget) (io.ReadCloser, error) {
+func (t *testRegistryDelegate) LoadArtifact(mf ociutils.Manifest, source oras.ReadOnlyTarget) (io.ReadCloser, error) {
 	return source.Fetch(t.ctx, mf.Layers[0])
 }
 

--- a/internal/pkg/delegates/delta/deltadelegate.go
+++ b/internal/pkg/delegates/delta/deltadelegate.go
@@ -15,7 +15,6 @@ import (
 	registrydelegate "github.com/unbasical/doras/internal/pkg/delegates/registry"
 
 	"github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/unbasical/doras/pkg/constants"
 )
 
@@ -32,7 +31,7 @@ func NewDeltaDelegate() DeltaDelegate {
 	}
 }
 
-func (d *delegate) IsDummy(mf v1.Manifest) (isDummy bool, expired bool) {
+func (d *delegate) IsDummy(mf ociutils.Manifest) (isDummy bool, expired bool) {
 	if mf.Annotations[constants.DorasAnnotationIsDummy] != "true" {
 		return false, false
 	}
@@ -112,10 +111,10 @@ func (d *delegate) CreateDelta(ctx context.Context, from, to io.ReadCloser, mani
 
 // DeltaDelegate abstracts over operations that are required to create deltas.
 type DeltaDelegate interface {
-	// IsDummy checks if the provided v1.Manifest refers to a dummy image that has not expired.
+	// IsDummy checks if the provided ociutils.Manifest refers to a dummy image that has not expired.
 	// Dummy images are used to communicate to other Doras instances that a server is working on creating this delta.
 	// This method should handle synchronization at the instance level.
-	IsDummy(mf v1.Manifest) (isDummy bool, expired bool)
+	IsDummy(mf ociutils.Manifest) (isDummy bool, expired bool)
 	// GetDeltaLocation returns the image at which the delta with the given options is/should be stored.
 	GetDeltaLocation(deltaMf registrydelegate.DeltaManifestOptions) (string, error)
 	// CreateDelta constructs the delta and pushes it to the registry.

--- a/internal/pkg/utils/ociutils/image.go
+++ b/internal/pkg/utils/ociutils/image.go
@@ -10,13 +10,11 @@ import (
 	"strings"
 
 	"golang.org/x/net/idna"
-
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ParseManifestJSON return the v1.manifest that is yielded by the reader.
-func ParseManifestJSON(data io.Reader) (*v1.Manifest, error) {
-	var manifest *v1.Manifest
+// ParseManifestJSON return the Manifest that is yielded by the reader.
+func ParseManifestJSON(data io.Reader) (*Manifest, error) {
+	var manifest *Manifest
 	err := json.NewDecoder(data).Decode(&manifest)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/utils/ociutils/manifest.go
+++ b/internal/pkg/utils/ociutils/manifest.go
@@ -2,13 +2,14 @@ package ociutils
 
 import (
 	"errors"
+	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/unbasical/doras/pkg/constants"
 )
 
 // ExtractPathFromManifest returns the path information and whether the artifact contains an archive.
 // The information is expected to be stored in the Manifest's annotations.
-func ExtractPathFromManifest(mf *v1.Manifest) (path string, isArchive bool, err error) {
+func ExtractPathFromManifest(mf *Manifest) (path string, isArchive bool, err error) {
 	if unpack, ok := mf.Annotations[constants.OrasContentUnpack]; ok && unpack == "true" {
 		isArchive = true
 	}
@@ -17,4 +18,31 @@ func ExtractPathFromManifest(mf *v1.Manifest) (path string, isArchive bool, err 
 		return "", isArchive, errors.New("missing file title")
 	}
 	return path, isArchive, nil
+}
+
+// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
+type Manifest struct {
+	specs.Versioned
+
+	// MediaType specifies the type of this document data structure e.g. `application/vnd.oci.image.manifest.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
+	// ArtifactType specifies the IANA media type of artifact when the manifest is used for an artifact.
+	ArtifactType string `json:"artifactType,omitempty"`
+
+	// Config references a configuration object for a container, by digest.
+	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
+	Config v1.Descriptor `json:"config"`
+
+	// Layers is an indexed list of layers referenced by the manifest.
+	Layers []v1.Descriptor `json:"layers"`
+
+	// Blobs is an indexed list of blobs referenced by the manifest.
+	Blobs []v1.Descriptor `json:"blobs"`
+
+	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
+	Subject *v1.Descriptor `json:"subject,omitempty"`
+
+	// Annotations contains arbitrary metadata for the image manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/internal/pkg/utils/ociutils/manifest_test.go
+++ b/internal/pkg/utils/ociutils/manifest_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/unbasical/doras/pkg/constants"
 )
@@ -12,14 +11,14 @@ import (
 func TestExtractPathFromManifest(t *testing.T) {
 	tests := []struct {
 		name            string
-		manifest        *v1.Manifest
+		manifest        *Manifest
 		expectedPath    string
 		expectedArchive bool
 		expectedErr     error
 	}{
 		{
 			name: "Valid manifest with archive",
-			manifest: &v1.Manifest{
+			manifest: &Manifest{
 				Annotations: map[string]string{
 					constants.OrasContentUnpack:      "true",
 					"org.opencontainers.image.title": "file.txt",
@@ -31,7 +30,7 @@ func TestExtractPathFromManifest(t *testing.T) {
 		},
 		{
 			name: "Valid manifest without archive",
-			manifest: &v1.Manifest{
+			manifest: &Manifest{
 				Annotations: map[string]string{
 					"org.opencontainers.image.title": "file.txt",
 				},
@@ -42,7 +41,7 @@ func TestExtractPathFromManifest(t *testing.T) {
 		},
 		{
 			name: "Missing file title",
-			manifest: &v1.Manifest{
+			manifest: &Manifest{
 				Annotations: map[string]string{
 					constants.OrasContentUnpack: "true",
 				},
@@ -53,7 +52,7 @@ func TestExtractPathFromManifest(t *testing.T) {
 		},
 		{
 			name: "Empty annotations",
-			manifest: &v1.Manifest{
+			manifest: &Manifest{
 				Annotations: map[string]string{},
 			},
 			expectedPath:    "",

--- a/pkg/client/edgeapi/client.go
+++ b/pkg/client/edgeapi/client.go
@@ -210,7 +210,7 @@ func (c *Client) ReadDeltaAsStream(from, to string, acceptedAlgorithms []string)
 		return nil, "", nil, err
 	}
 	defer funcutils.PanicOrLogOnErr(rc.Close, false, "failed to close fetch reader")
-	var mf v1.Manifest
+	var mf ociutils.Manifest
 	err = json.NewDecoder(rc).Decode(&mf)
 	if err != nil {
 		return nil, "", nil, err


### PR DESCRIPTION
## Description

- Add new type for OCI manifests that also include a Blob key.
- Use this new type to support older oras manifestsv which use the blobs key instead of layers.