### PR TITLE
clean up temporary directories

### DIFF
--- a/internal/pkg/delta/bsdiff/applier.go
+++ b/internal/pkg/delta/bsdiff/applier.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/unbasical/doras/pkg/algorithm/delta"
+	"github.com/unbasical/doras/pkg/constants"
 
 	bspatchdep "github.com/gabstv/go-bsdiff/pkg/bspatch"
 	"github.com/unbasical/doras/internal/pkg/utils/funcutils"
@@ -59,7 +60,7 @@ func (a *patcher) PatchFilesystem(artifactDir string, patch io.Reader, expected 
 	}
 	defer funcutils.PanicOrLogOnErr(fpOld.Close, false, "failed to close file")
 
-	fpTemp, err := os.CreateTemp(a.tmpDir, "bsdiff-temp-*")
+	fpTemp, err := os.CreateTemp(a.tmpDir, constants.TempPrefixBsdiff+"*")
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/delta/tardiff/applier.go
+++ b/internal/pkg/delta/tardiff/applier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/unbasical/doras/internal/pkg/utils/tarutils"
 	"github.com/unbasical/doras/internal/pkg/utils/writerutils"
 	"github.com/unbasical/doras/pkg/algorithm/delta"
+	"github.com/unbasical/doras/pkg/constants"
 
 	"github.com/unbasical/doras/internal/pkg/delta/tarfsdatasource"
 	"github.com/unbasical/doras/internal/pkg/utils/funcutils"
@@ -29,7 +30,7 @@ type applier struct {
 
 func (a *applier) PatchFilesystem(artifactDir string, patch io.Reader, expected *digest.Digest) error {
 	datasource := tarpatch.NewFilesystemDataSource(artifactDir)
-	tempfile, err := os.CreateTemp(a.tmpDir, "tarpatch-temp-*")
+	tempfile, err := os.CreateTemp(a.tmpDir, constants.TempPrefixTarpatch+"*")
 	if err != nil {
 		return err
 	}
@@ -44,7 +45,7 @@ func (a *applier) PatchFilesystem(artifactDir string, patch io.Reader, expected 
 	if err != nil {
 		return err
 	}
-	extractDir, err := os.MkdirTemp(a.tmpDir, "tar-extract-dir-*")
+	extractDir, err := os.MkdirTemp(a.tmpDir, constants.TempPrefixTarExtract+"*")
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/utils/fileutils/fileutils.go
+++ b/internal/pkg/utils/fileutils/fileutils.go
@@ -91,7 +91,7 @@ func CompareDirectoriesHasher(dir1, dir2 string, h hash.Hash) (bool, error) {
 // It assumes that proto is a pointer to a struct.
 func cloneHash(h hash.Hash) hash.Hash {
 	v := reflect.ValueOf(h)
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		panic("provided hash is not a pointer")
 	}
 	newInstance := reflect.New(v.Elem().Type()).Interface().(hash.Hash)

--- a/pkg/client/updater/builder.go
+++ b/pkg/client/updater/builder.go
@@ -125,6 +125,11 @@ func NewClient(options ...func(*Client)) (*Client, error) {
 		return nil, fmt.Errorf("failed to create patcher working directory: %w", err)
 	}
 
+	// Sweep leftover temporary artifacts from previous pulls that were interrupted
+	// before their deferred cleanup could run (reboot, OOM kill, disk-full). This
+	// prevents unbounded accumulation of large temp files in the internal directory.
+	cleanupStaleTempArtifacts(client.opts.InternalDirectory, client.patcherTmpDir)
+
 	stateManager, err := statemanager.NewFromDisk(initialState, statePath)
 	if err != nil {
 		return nil, err

--- a/pkg/client/updater/client.go
+++ b/pkg/client/updater/client.go
@@ -138,7 +138,7 @@ func (c *Client) pullDeltaImageAsync(target string, repoName string, currentVers
 		return false, nil
 	}
 	log.Info("attempting delta update")
-	deltaDir, err := os.MkdirTemp(c.opts.InternalDirectory, "deltas-*")
+	deltaDir, err := os.MkdirTemp(c.opts.InternalDirectory, constants.TempPrefixDeltas+"*")
 	if err != nil {
 		return false, err
 	}
@@ -201,7 +201,7 @@ func (c *Client) pullFullImage(targetImage string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	intermediateDir, err := os.MkdirTemp(c.opts.InternalDirectory, "intermediate-*")
+	intermediateDir, err := os.MkdirTemp(c.opts.InternalDirectory, constants.TempPrefixIntermediate+"*")
 	if err != nil {
 		return false, err
 	}
@@ -214,7 +214,7 @@ func (c *Client) pullFullImage(targetImage string) (bool, error) {
 		return false, err
 	}
 	// this directory gets filled with all artifacts and replaces the output directory once completed
-	extractDir, err := os.MkdirTemp(c.opts.InternalDirectory, "extract-*")
+	extractDir, err := os.MkdirTemp(c.opts.InternalDirectory, constants.TempPrefixExtract+"*")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/client/updater/client_test.go
+++ b/pkg/client/updater/client_test.go
@@ -612,6 +612,15 @@ func TestClient_PullAsyncTardiff(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				// Reset the download-stats directory between iterations. The two
+				// keepOldDir runs share the same statsDir, and stat files are named
+				// by whole-second timestamps; without this, two runs straddling a
+				// second boundary accumulate and double the summed byte count.
+				// RemoveAll (not CleanDirectory) tolerates the dir not existing yet,
+				// since the stats observer creates it lazily on first write.
+				if err = os.RemoveAll(statsDir); err != nil {
+					t.Fatal(err)
+				}
 				if tt.version != nil {
 					p := descriptorsToPaths[tt.version.Digest]
 					err := tarutils.ExtractCompressedTar(outDir, "", p, nil, gzip2.NewDecompressor())

--- a/pkg/client/updater/temps.go
+++ b/pkg/client/updater/temps.go
@@ -1,0 +1,89 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/unbasical/doras/pkg/constants"
+)
+
+// internalDirTempPrefixes are the prefixes of temporary entries created directly
+// under the internal directory during pull operations.
+var internalDirTempPrefixes = []string{
+	constants.TempPrefixDeltas,
+	constants.TempPrefixIntermediate,
+	constants.TempPrefixExtract,
+}
+
+// patcherDirTempPrefixes are the prefixes of temporary entries created under the
+// patcher directory while applying deltas.
+var patcherDirTempPrefixes = []string{
+	constants.TempPrefixTarpatch,
+	constants.TempPrefixTarExtract,
+	constants.TempPrefixBsdiff,
+}
+
+// cleanupStaleTempArtifacts removes leftover temporary files and directories from
+// previous pull operations that were interrupted (e.g. by a reboot, an OOM kill,
+// or a disk-full error) before their in-function deferred cleanup could run.
+//
+// Cleanup only ever removes entries whose names match one of the well-known temp
+// prefixes (see pkg/constants). Persistent state is never touched: the state file
+// (doras-state.json), its lock file, the fetcher download cache and the patcher
+// directory itself are all left in place.
+//
+// This assumes a single client owns a given internal directory at a time (the way
+// the updater is used in practice). If that assumption is ever relaxed so that
+// multiple clients share one internal directory concurrently, this prefix-only
+// sweep could race a live patch and would need an age guard.
+//
+// The cleanup is best-effort: individual removal failures are logged and skipped
+// rather than aborting client initialisation.
+func cleanupStaleTempArtifacts(internalDir, patcherDir string) {
+	removed := removeMatchingEntries(internalDir, internalDirTempPrefixes)
+	removed += removeMatchingEntries(patcherDir, patcherDirTempPrefixes)
+	if removed > 0 {
+		log.Infof("removed %d stale temporary artifact(s) from previous interrupted pulls", removed)
+	}
+}
+
+// removeMatchingEntries removes every entry in dir whose name starts with one of
+// the provided prefixes. It returns the number of entries that were removed.
+// Errors reading the directory or removing individual entries are logged and do
+// not stop the sweep.
+func removeMatchingEntries(dir string, prefixes []string) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.WithError(err).Warnf("failed to scan %q for stale temporary artifacts", dir)
+		}
+		return 0
+	}
+	var removed int
+	for _, entry := range entries {
+		name := entry.Name()
+		if !hasAnyPrefix(name, prefixes) {
+			continue
+		}
+		fullPath := filepath.Join(dir, name)
+		if err := os.RemoveAll(fullPath); err != nil {
+			log.WithError(err).Warnf("failed to remove stale temporary artifact %q", fullPath)
+			continue
+		}
+		log.Debugf("removed stale temporary artifact %q", fullPath)
+		removed++
+	}
+	return removed
+}
+
+// hasAnyPrefix reports whether name starts with any of the provided prefixes.
+func hasAnyPrefix(name string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/client/updater/temps_test.go
+++ b/pkg/client/updater/temps_test.go
@@ -1,0 +1,149 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unbasical/doras/pkg/constants"
+)
+
+// writeFile creates a file with some content, failing the test on error.
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write %q: %v", path, err)
+	}
+}
+
+// mkdir creates a directory, failing the test on error.
+func mkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("failed to mkdir %q: %v", path, err)
+	}
+}
+
+func TestCleanupStaleTempArtifacts(t *testing.T) {
+	internalDir := t.TempDir()
+	patcherDir := filepath.Join(internalDir, "patcher-dir")
+	mkdir(t, patcherDir)
+
+	// Stale temp entries under the internal directory (mix of files and dirs).
+	staleInternal := []string{
+		constants.TempPrefixDeltas + "123",
+		constants.TempPrefixIntermediate + "abc",
+		constants.TempPrefixExtract + "xyz",
+	}
+	for _, name := range staleInternal {
+		// exercise both file and directory removal
+		p := filepath.Join(internalDir, name)
+		mkdir(t, p)
+		writeFile(t, filepath.Join(p, "inner"))
+	}
+
+	// Stale temp entries under the patcher directory.
+	staleTarpatchFile := filepath.Join(patcherDir, constants.TempPrefixTarpatch+"999")
+	writeFile(t, staleTarpatchFile)
+	staleTarExtractDir := filepath.Join(patcherDir, constants.TempPrefixTarExtract+"999")
+	mkdir(t, staleTarExtractDir)
+	staleBsdiffFile := filepath.Join(patcherDir, constants.TempPrefixBsdiff+"999")
+	writeFile(t, staleBsdiffFile)
+
+	// Protected entries that must survive.
+	stateFile := filepath.Join(internalDir, "doras-state.json")
+	writeFile(t, stateFile)
+	lockFile := filepath.Join(internalDir, "doras-state.json.lock")
+	writeFile(t, lockFile)
+	fetcherDir := filepath.Join(internalDir, "fetcher")
+	mkdir(t, filepath.Join(fetcherDir, "completed"))
+	fetcherBlob := filepath.Join(fetcherDir, "completed", "blob")
+	writeFile(t, fetcherBlob)
+	unrelatedFile := filepath.Join(internalDir, "something-else")
+	writeFile(t, unrelatedFile)
+	// A patcher-dir entry that does not match any temp prefix must also survive.
+	patcherKeep := filepath.Join(patcherDir, "keep-me")
+	writeFile(t, patcherKeep)
+
+	cleanupStaleTempArtifacts(internalDir, patcherDir)
+
+	// All stale temp entries must be gone.
+	gone := []string{
+		filepath.Join(internalDir, staleInternal[0]),
+		filepath.Join(internalDir, staleInternal[1]),
+		filepath.Join(internalDir, staleInternal[2]),
+		staleTarpatchFile,
+		staleTarExtractDir,
+		staleBsdiffFile,
+	}
+	for _, p := range gone {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected stale temp %q to be removed, stat err = %v", p, err)
+		}
+	}
+
+	// All protected entries must still exist.
+	kept := []string{
+		stateFile,
+		lockFile,
+		fetcherDir,
+		fetcherBlob,
+		unrelatedFile,
+		patcherDir,
+		patcherKeep,
+	}
+	for _, p := range kept {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected protected entry %q to survive, stat err = %v", p, err)
+		}
+	}
+}
+
+// TestCleanupStaleTempArtifacts_MissingDirs ensures the sweep is a no-op (no
+// panic, no error surfaced) when the directories do not exist.
+func TestCleanupStaleTempArtifacts_MissingDirs(t *testing.T) {
+	base := t.TempDir()
+	cleanupStaleTempArtifacts(
+		filepath.Join(base, "does-not-exist"),
+		filepath.Join(base, "does-not-exist", "patcher-dir"),
+	)
+}
+
+// TestNewClientCleansStaleTempArtifacts verifies the sweep is wired into client
+// construction: pre-existing patcher-dir/internal-dir temps are removed while the
+// fetcher cache is preserved.
+func TestNewClientCleansStaleTempArtifacts(t *testing.T) {
+	internalDir := t.TempDir()
+	outputDir := t.TempDir()
+	patcherDir := filepath.Join(internalDir, "patcher-dir")
+	mkdir(t, patcherDir)
+
+	staleTarpatch := filepath.Join(patcherDir, constants.TempPrefixTarpatch+"stale")
+	writeFile(t, staleTarpatch)
+	staleDeltas := filepath.Join(internalDir, constants.TempPrefixDeltas+"stale")
+	mkdir(t, staleDeltas)
+
+	// Fetcher cache content that must be preserved across construction.
+	fetcherBlob := filepath.Join(internalDir, "fetcher", "completed", "blob")
+	mkdir(t, filepath.Dir(fetcherBlob))
+	writeFile(t, fetcherBlob)
+
+	_, err := NewClient(
+		WithInternalDirectory(internalDir),
+		WithOutputDirectory(outputDir),
+		WithRemoteURL("http://localhost:0"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	if _, err := os.Stat(staleTarpatch); !os.IsNotExist(err) {
+		t.Errorf("expected stale tarpatch temp to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(staleDeltas); !os.IsNotExist(err) {
+		t.Errorf("expected stale deltas temp to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(fetcherBlob); err != nil {
+		t.Errorf("expected fetcher cache to survive, stat err = %v", err)
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,3 +37,35 @@ const OrasContentUnpack = "io.deis.oras.content.unpack"
 
 // OciImageTitle is used to extract the titles of container layers from annotations.
 const OciImageTitle = "org.opencontainers.image.title"
+
+// Temp-dir/file name prefixes used during patch operations.
+//
+// These are the single source of truth shared between the temp creation sites
+// (the updater client and the delta applier implementations) and the updater's
+// startup cleanup routine, so the two cannot drift out of sync if a prefix is
+// ever renamed.
+//
+// Convention: os.MkdirTemp / os.CreateTemp callers append "*" to form the glob
+// pattern (e.g. TempPrefixDeltas + "*"). The cleanup routine matches leftover
+// entries via strings.HasPrefix using the bare prefix.
+const (
+	// TempPrefixDeltas is used for the temp dir holding fetched delta artifacts.
+	// Created directly under the internal directory.
+	TempPrefixDeltas = "deltas-"
+	// TempPrefixIntermediate is used for the temp dir holding fetched full-image
+	// artifacts before extraction. Created directly under the internal directory.
+	TempPrefixIntermediate = "intermediate-"
+	// TempPrefixExtract is used for the temp dir a full image is extracted into
+	// before it replaces the output directory. Created under the internal directory.
+	TempPrefixExtract = "extract-"
+
+	// TempPrefixTarpatch is used for the temp file holding a fully applied tardiff
+	// patch. Created under the patcher directory.
+	TempPrefixTarpatch = "tarpatch-temp-"
+	// TempPrefixTarExtract is used for the temp dir a patched tar is extracted into.
+	// Created under the patcher directory.
+	TempPrefixTarExtract = "tar-extract-dir-"
+	// TempPrefixBsdiff is used for the temp file holding an applied bsdiff patch.
+	// Created under the patcher directory.
+	TempPrefixBsdiff = "bsdiff-temp-"
+)


### PR DESCRIPTION
this prevents bloat and leftover artifacts if the patcher is killed during execution